### PR TITLE
Set tools namespace refresh dirs

### DIFF
--- a/env/dev/src/dev.clj
+++ b/env/dev/src/dev.clj
@@ -2,7 +2,15 @@
   (:require [ook.main :as main]
             [integrant.repl :as igr :refer [go reset halt]]
             [integrant.repl.state :refer [system config]]
+            [clojure.tools.namespace.repl :as tns]
             [clojure.java.io :as io]))
+
+;; only automatically refresh/require project directories. Without
+;; this tools.namespace (used by igr/reset) will load all namespaces
+;; in gitlib dependencies, and load namespaces that require extra
+;; dependencies.
+(tns/set-refresh-dirs "src" "test" "env/dev/src")
+
 
 ;; require scope capture as a side effect
 (require 'sc.api)
@@ -10,6 +18,8 @@
 (def profiles (concat main/core-profiles
                       [(io/resource "dev.edn")
                        (io/resource "local.edn")]))
+
+
 
 (igr/set-prep!
   #(do


### PR DESCRIPTION
This prevents igr/reset loading namespaces found in .gitdeps that we
don't explicitly depend on