### PR TITLE
Update drafter-client to avoid transitive deps issue

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -13,9 +13,8 @@
 
 
         drafter-client/drafter-client {:git/url "git@github.com:Swirrl/drafter.git"
-                                       :sha "250df5d226f5f8f299038f86e095935e9024b3a3"
+                                       :sha "7c9302bf7dface04feea226b0175c73937ec18cf"
                                        :deps/root "drafter-client"}
-        com.auth0/jwks-rsa {:mvn/version "0.8.1"}
 
         ;; ETL
         clj-http/clj-http {:mvn/version "3.10.0"}


### PR DESCRIPTION
Prior to this consumers of drafter-client would need to include the
auth0 deps themselves.