### PR TITLE
Shorter filter query params

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -36,7 +36,8 @@
         day8.re-frame/async-flow-fx {:mvn/version "0.2.0"}
         reagent/reagent {:mvn/version "1.0.0"}
         com.cognitect/transit-cljs {:mvn/version "0.8.264"}
-        cljs-ajax/cljs-ajax {:mvn/version "0.8.1"}}
+        cljs-ajax/cljs-ajax {:mvn/version "0.8.1"}
+        mvxcvi/alphabase {:mvn/version "2.1.0"}}
 
  :mvn/repos
  {"swirrl-jars-releases" {:url "s3://swirrl-jars/releases/"}

--- a/package.json
+++ b/package.json
@@ -8,19 +8,19 @@
     "build-ci": "shadow-cljs compile ci"
   },
   "devDependencies": {
-    "highlight.js": "^10.1.2",
+    "@testing-library/react": "^11.2.5",
+    "@testing-library/user-event": "^12.7.1",
+    "highlight.js": "10.7.1",
     "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-cljs-test": "^0.1.0",
-    "marked": "^1.1.1",
+    "react-highlight.js": "1.0.7",
     "shadow-cljs": "2.11.18"
   },
   "dependencies": {
-    "@testing-library/react": "^11.2.5",
-    "@testing-library/user-event": "^12.7.1",
     "create-react-class": "15.7.0",
+    "pako": "^2.0.3",
     "react": "17.0.1",
-    "react-dom": "17.0.1",
-    "react-highlight.js": "1.0.7"
+    "react-dom": "17.0.1"
   }
 }

--- a/src/ook/params/parse.cljc
+++ b/src/ook/params/parse.cljc
@@ -1,13 +1,28 @@
 (ns ook.params.parse
   (:require
+   #?@(:cljs [["pako" :as pako]])
+   #?@(:clj [[clojure.java.io :as io]])
+   [alphabase.base58 :as base58]
    [ook.util :as u]
-   [ook.concerns.transit :as t]))
+   [ook.concerns.transit :as t])
+  #?(:clj (:import [java.util.zip GZIPInputStream])))
 
-(defn serialize-filter-state [filter-state]
-  (t/write-string filter-state))
+#?(:cljs
+   (defn serialize-filter-state [filter-state]
+     (some-> filter-state t/write-string pako/gzip base58/encode)))
 
-(defn deserialize-filter-state [filter-state]
-  (t/read-string filter-state))
+(defn gzipped-bytes->str [bytes]
+  #?(:cljs
+     (when bytes
+       (pako/ungzip bytes #js{:to "string"}))
+
+     :clj
+     (when bytes
+       (with-open [in (GZIPInputStream. (io/input-stream bytes))]
+         (slurp in)))))
+
+(defn deserialize-filter-state [encoded-filter-state]
+  (some-> encoded-filter-state base58/decode gzipped-bytes->str t/read-string))
 
 (defn get-facets
   [{:keys [query-params]}]

--- a/src/ook/search/fake.clj
+++ b/src/ook/search/fake.clj
@@ -7,7 +7,7 @@
   db/SearchBackend
 
   (get-datasets-for-facets [_ filters]
-    (if (= filters {"facet1" {"codelist1" ["code1"]}})
+    (if (= filters {"facet1" {"codelist1" #{"code1"}}})
       "valid response"
       "something wrong with filter parsing..."))
 

--- a/test/ook/handler_test.clj
+++ b/test/ook/handler_test.clj
@@ -46,7 +46,7 @@
 
           (testing "with filters works"
             (let [response (request-transit
-                            "datasets?filters=%5B%22%5E%20%22%2C%22facet1%22%2C%5B%22%5E%20%22%2C%22codelist1%22%2C%5B%22code1%22%5D%5D%5D")]
+                            "datasets?filters=2GTHaVo1UkANYaYQfCLr44iQXQkArX445bRsRrWMzXwE7aQG5EbdQJQdUoD42FG8E7uDJvcnw6NJ4Udmq")]
               (is (= 200 (:status response)))
               (is (= "application/transit+json" (get-in response [:headers "Content-Type"])))
               (is (str/includes? (:body response) "valid response"))))))

--- a/test/ook/params/parse_test.cljc
+++ b/test/ook/params/parse_test.cljc
@@ -1,0 +1,35 @@
+(ns ook.params.parse-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ook.params.parse :as sut]))
+
+(let [filter-state {"Product"
+                    {"data/gss_data/trade/ons-pink-book-trade-in-services#scheme/pink-book-services"
+                     #{"data/gss_data/trade/ons-pink-book-trade-in-services#concept/pink-book-services/10.3.2"}}}]
+  #?(:cljs
+     (deftest cljs-round-tripping-filter-state-test
+       (testing "works with empty filter state"
+         (let [encoded (sut/serialize-filter-state {})]
+           (is (= "y2Dy1JNvyeAhh2R1f6EYn8XotFEx7MEEhcT" encoded))
+           (is (= {} (sut/deserialize-filter-state encoded)))))
+
+       (testing "works with nil filter state"
+         (is (= nil (sut/serialize-filter-state nil)))
+         (is (= nil (sut/deserialize-filter-state nil))))
+
+       (testing "gzips and base58 encodes and decodes filter state"
+         (let [encoded (sut/serialize-filter-state filter-state)]
+
+           (is (= "AcNGXCgrRzto9cvt16NhTiUe9vvaykiUHSRBkcgpXMkBGg7QDLDZz6tG6LoqYYnMjcCkrcLTH3DzNDuD6DZMisLjrTunq9VHDzYaEo4LLWgYeSX93G9q4gcHBGww9TsHAE4wJDxqZhNdT3VybygbWs6JLCHUag3cGvhHuvRa8j8T" encoded))
+           (is (= filter-state (sut/deserialize-filter-state encoded))))))
+
+     :clj
+     (deftest clj-deserializing-filter-state
+       (testing "works with empty filter state"
+         (is (= {} (sut/deserialize-filter-state "y2Dy1JNvyeAhh2R1f6EYn8XotFEx7MEEhcT"))))
+
+       (testing "works with nil filter state"
+         (is (= nil (sut/deserialize-filter-state nil))))
+
+       (testing "can understand an encoded filter state"
+         (is (= filter-state
+                (sut/deserialize-filter-state "AcNGXCgrRzto9cvt16NhTiUe9vvaykiUHSRBkcgpXMkBGg7QDLDZz6tG6LoqYYnMjcCkrcLTH3DzNDuD6DZMisLjrTunq9VHDzYaEo4LLWgYeSX93G9q4gcHBGww9TsHAE4wJDxqZhNdT3VybygbWs6JLCHUag3cGvhHuvRa8j8T")))))))

--- a/test/ook/test/util/setup.cljc
+++ b/test/ook/test/util/setup.cljc
@@ -12,7 +12,7 @@
        :cljs [[reagent.dom :as rdom]
               [re-frame.core :as rf]
               [ook.reframe.router :as router]
-              [ook.concerns.transit :as transit]
+              [ook.params.parse :as p]
               [day8.re-frame.async-flow-fx]
               [ook.reframe.events]
               [ook.reframe.subs]
@@ -122,8 +122,8 @@
        (rf/reg-event-fx
         :http/fetch-datasets
         (fn [_ [_ filters]]
-          (reset! dataset-request (transit/read-string filters))
-          {:dispatch [:http.datasets/success (get datasets (transit/read-string filters) [])]})))
+          (reset! dataset-request (p/deserialize-filter-state filters))
+          {:dispatch [:http.datasets/success (get datasets (p/deserialize-filter-state filters) [])]})))
 
      (def last-navigation (atom nil))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -825,10 +825,10 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-highlight.js@^10.1.2:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.6.0.tgz#0073aa71d566906965ba6e1b7be7b2682f5e18b6"
-  integrity sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==
+highlight.js@10.7.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.1.tgz#a8ec4152db24ea630c90927d6cae2a45f8ecb955"
+  integrity sha512-S6G97tHGqJ/U8DsXcEdnACbirtbx58Bx9CzIVeYli8OuswCfYI/LsXH2EiGcoGio1KAC3x4mmUwulOllJ2ZyRA==
 
 highlight.js@^9.3.0:
   version "9.18.5"
@@ -1029,11 +1029,6 @@ lz-string@^1.4.4:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
-marked@^1.1.1:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.9.tgz#53786f8b05d4c01a2a5a76b7d1ec9943d29d72dc"
-  integrity sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
-
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -1162,6 +1157,11 @@ os-browserify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
+
+pako@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.3.tgz#cdf475e31b678565251406de9e759196a0ea7a43"
+  integrity sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==
 
 pako@~1.0.5:
   version "1.0.11"


### PR DESCRIPTION
This implements [option 2](https://www.notion.so/swirrl/Encoding-Filter-Facet-Parameters-600c4915205b490c9cbe14c85a795349#35c044eb352c47518e54064a875edab0) from Rick's document about shortening query params (gzipping then base58 encoding filter configs serialized to a transit string -- base58 because it's URL friendly by default to avoid an extra step of having to handle non-URL friendly chars, transit because it can preserve clojure data structures and types). Ultimately we might switch to whatever gets implemented in muttnik (currently being discussed/implemented [here](https://github.com/Swirrl/muttnik/issues/1178)), but for now this is a self-contained option (i.e. doesn't require any extra ops or maintaining indexes etc) that at least buys us a non-trivial amount of extra space (~15x or so for most filter configurations). Fixes #75.
