### PR TITLE
properly parse csv query results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,6 @@ workflows:
             branches:
               only:
                 - main
-                - etl-use-graph-versions
+                - parse-csv-query-results
           requires:
             - run_tests

--- a/deps.edn
+++ b/deps.edn
@@ -30,6 +30,7 @@
 
         clojurewerkz/elastisch {:mvn/version "5.0.0-beta1"}
         org.clojure/data.json {:mvn/version "2.4.0"}
+        org.clojure/data.csv {:mvn/version "1.0.1"}
 
         hiccup/hiccup {:mvn/version "2.0.0-alpha2"}
 

--- a/src/ook/etl.clj
+++ b/src/ook/etl.clj
@@ -1,5 +1,6 @@
 (ns ook.etl
   (:require
+   [clojure.data.csv :as csv]
    [clojure.java.io :as io]
    [clojure.string :as s]
    [clojure.tools.logging :as log]
@@ -98,13 +99,14 @@
   Pages are vectors - the variable name followed by the values."
   [file page-size]
   (let [rdr (io/reader file)
-        var-name (.readLine rdr)
-        read-lines (fn this [r]
+        data (map first (csv/read-csv rdr))
+        var-name (first data)
+        read-lines (fn this [data]
                      (lazy-seq
-                      (if-let [line (.readLine r)]
-                        (cons line (this r))
-                        (.close r))))]
-    (->> (read-lines rdr)
+                      (if-let [line (first data)]
+                        (cons line (this (rest data)))
+                        (.close rdr))))]
+    (->> (read-lines (rest data))
          (partition-all page-size)
          (map (fn [page] (cons var-name page))))))
 
@@ -120,6 +122,8 @@
        (let [client (interceptors/accept client "text/csv")]
          (spill-to-disk (query client subject-query) subject-cache))
        (read-paged subject-cache page-size)
+       ;; TODO this doesn't look safe. read-paged returns a lazy sequence which
+       ;; could still be trying to read from subject-cache after we delete it.
        (finally (.delete subject-cache)))))
   ([client graphs subject-query page-size]
    (mapcat (fn [graph]
@@ -364,7 +368,7 @@
 (defmethod ig/init-key ::target-datasets [_ {:keys [sparql client] :as opts}]
   (if sparql
     (let [client (interceptors/accept client "text/csv")
-          results (s/split-lines (slurp (io/reader (query client sparql))))]
+          results (map first (csv/read-csv (query client sparql)))]
       (rest results))
     opts))
 


### PR DESCRIPTION
The problem described in #122 is not actually an issue with the string interpolation, it's an issue with parsing the results of a SPARQL query.

We ask for SPARQL query results in `text/csv` format, but parse them as simple line separated values. This works fine until one of the values is quoted (because it contains a comma, newline, etc). This PR pulls in `clojure.data.csv` to parse the response as a proper CSV.

closes #122 
closes #121 